### PR TITLE
lawrap tests

### DIFF
--- a/lawrap_tests/CMakeLists.txt
+++ b/lawrap_tests/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+project(lawrap_tests)
+
+add_executable(test_c test.c)
+add_executable(test_cxx test.cc)
+
+find_package(LAWrap REQUIRED)
+target_link_libraries(test_c PRIVATE LAWrap::lawrap)
+target_link_libraries(test_cxx PRIVATE LAWrap::lawrap)
+

--- a/lawrap_tests/test.c
+++ b/lawrap_tests/test.c
@@ -1,0 +1,24 @@
+#include <lawrap/blas.h>
+#include <lawrap/lapack.h>
+
+int main()
+{
+   double A[10][10], B[10][10], C[10][10], w[10];
+   int i, j, info;
+
+   for (i = 0;i < 10;i++)
+   {
+       for (j = 0;j < 10;j++)
+       {
+           A[i][j] = i+j;
+           B[i][j] = 1;
+       }
+   }
+
+   dgemm('N', 'T', 10, 10, 10, 2.0, A, 10, B, 10, 0.0, C, 10);
+   info = dsyev('V', 'U', 10, A, 10, w);
+   printf("info %d\n", info);
+
+   return info;
+}
+

--- a/lawrap_tests/test.cc
+++ b/lawrap_tests/test.cc
@@ -1,0 +1,32 @@
+#include <lawrap/blas.h>
+#include <lawrap/lapack.h>
+
+int main()
+{
+   using namespace LAWrap;
+
+    double w[10];
+   //const double * A, * B, * C, * w;
+   //double A[10][10], B[10][10], C[10][10], w[10];
+  double *A = new double[100];
+  double *B = new double[100];
+  double *C = new double[100];
+ 
+  for(int i = 0; i < 100; i++) A[i] = i*i;
+
+   //for (int i = 0;i < 10;i++)
+   //{
+   //    for (int j = 0;j < 10;j++)
+   //    {
+   //        A[i][j] = i+j;
+   //        B[i][j] = 1;
+   //    }
+   //}
+
+   LAWrap::gemm('N', 'T', 10, 10, 10, 2.0, A, 10, B, 10, 0.0, C, 10);
+   int info = heev('V', 'U', 10, A, 10, w);
+   printf("info %d\n", info);
+
+   return info;
+}
+

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,39 @@ class cmake_build(install):
         if "[100%]" not in output:
             raise Exception("Build error. Output as follows:\n" + output)
 
+class lawrap_build(install):
+
+    def run(self):
+
+        # Find build directory (in-place)
+        abspath = os.path.abspath(os.path.dirname(__file__))
+        build_path = os.path.join(abspath, "lawrap_tests")
+        os.chdir(build_path)
+        print(">>> cd {}".format(build_path))
+
+        # Run CMake command
+        print("Building CMake structures...")
+        output = sp.check_output(["cmake", "-H.", "-Bbuild"]).decode("UTF-8")
+        #output = sp.check_output(["cmake", "-H.", "-Bbuild", "-DLAWrap_DIR=/Users/loriab/linux/lawrap/lawrap-install/share/cmake/LAWrap"]).decode("UTF-8")
+        print(">>> cmake -H. -Bbuild\n{}".format(output))
+        if "Build files have been" not in output:
+            raise Exception("CMake error. Output as follows:\n" + output)
+
+        # Run install
+        print("Compiling...")
+        os.chdir('build')
+        output = sp.check_output(["make", "-j2"]).decode("UTF-8")
+        print(">>> make -j2\n{}".format(output))
+        if "[100%]" not in output:
+            raise Exception("Build error. Output as follows:\n" + output)
+
+        # Run test
+        print("Testing...")
+        output = sp.check_output(["./test_cxx"]).decode("UTF-8")
+        print(">>> ./test_cxx\n{}".format(output))
+#        if "[100%]" not in output:
+#            raise Exception("Build error. Output as follows:\n" + output)
+
 if __name__ == "__main__":
     setuptools.setup(
         name='quantum_python',
@@ -96,5 +129,6 @@ if __name__ == "__main__":
         zip_safe=False,
         cmdclass={
             'cmake': cmake_build,
+            'lawrap': lawrap_build,
         },
     )


### PR DESCRIPTION
rather ugly and generally fails with rpath error. `conda install lawrap -c psi4` should work on mac